### PR TITLE
Add Redis-backed rate limiter

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -51,11 +51,27 @@ var (
 			Usage:  "only run once, no looping",
 			EnvVar: "GCLOUD_CLEANUP_ONCE",
 		},
+		cli.StringFlag{
+			Name:   "rate-limit-redis-url",
+			Usage:  "URL to Redis instance to use for rate limiting",
+			EnvVar: "GCLOUD_CLEANUP_RATE_LIMIT_REDIS_URL",
+		},
+		cli.StringFlag{
+			Name:   "rate-limit-prefix",
+			Usage:  "prefix for the rate limit key in Redis",
+			EnvVar: "GCLOUD_CLEANUP_RATE_LIMIT_PREFIX",
+		},
+		cli.IntFlag{
+			Name:   "rate-limit-max-calls",
+			Value:  10,
+			Usage:  "number of calls per duration to let through to the GCE API",
+			EnvVar: "GCLOUD_CLEANUP_RATE_LIMIT_DURATION",
+		},
 		cli.DurationFlag{
-			Name:   "rate-limit-tick",
+			Name:   "rate-limit-duration",
 			Value:  1 * time.Second,
-			Usage:  "API usage rate limiter interval",
-			EnvVar: "GCLOUD_CLEANUP_RATE_LIMIT_TICK",
+			Usage:  "interval in which to let max-calls through to the GCE API",
+			EnvVar: "GCLOUD_CLEANUP_RATE_LIMIT_DURATION",
 		},
 		cli.IntFlag{
 			Name:   "image-limit",

--- a/image_cleaner_test.go
+++ b/image_cleaner_test.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/travis-ci/worker/ratelimit"
 )
 
 func TestNewImageCleaner(t *testing.T) {
 	log := logrus.New()
+	ratelimit := ratelimit.NewNullRateLimiter()
 
-	ic := newImageCleaner(nil, log, 1*time.Second,
+	ic := newImageCleaner(nil, log, ratelimit, 10, time.Second,
 		"foo-project", "http://foo.example.com", 20,
 		[]string{"name eq ^travis-test.*"}, true)
 

--- a/instance_cleaner_test.go
+++ b/instance_cleaner_test.go
@@ -6,13 +6,15 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/travis-ci/worker/ratelimit"
 )
 
 func TestNewInstanceCleaner(t *testing.T) {
 	log := logrus.New()
+	ratelimit := ratelimit.NewNullRateLimiter()
 	cutoffTime := time.Now().Add(-1 * time.Hour)
 
-	ic := newInstanceCleaner(nil, log, 1*time.Second,
+	ic := newInstanceCleaner(nil, log, ratelimit, 10, time.Second,
 		cutoffTime, "foo-project",
 		[]string{"name eq ^test.*"}, true)
 

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -1,0 +1,99 @@
+package ratelimit
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/garyburd/redigo/redis"
+)
+
+const (
+	redisRateLimiterPoolMaxActive   = 1
+	redisRateLimiterPoolMaxIdle     = 1
+	redisRateLimiterPoolIdleTimeout = 3 * time.Minute
+)
+
+type RateLimiter interface {
+	RateLimit(name string, maxCalls uint64, per time.Duration) (bool, error)
+}
+
+type redisRateLimiter struct {
+	pool   *redis.Pool
+	prefix string
+}
+
+type nullRateLimiter struct{}
+
+func NewRateLimiter(redisURL string, prefix string) RateLimiter {
+	return &redisRateLimiter{
+		pool: &redis.Pool{
+			Dial: func() (redis.Conn, error) {
+				return redis.DialURL(redisURL)
+			},
+			TestOnBorrow: func(c redis.Conn, _ time.Time) error {
+				_, err := c.Do("PING")
+				return err
+			},
+			MaxIdle:     redisRateLimiterPoolMaxIdle,
+			MaxActive:   redisRateLimiterPoolMaxActive,
+			IdleTimeout: redisRateLimiterPoolIdleTimeout,
+			Wait:        true,
+		},
+		prefix: prefix,
+	}
+}
+
+func NewNullRateLimiter() RateLimiter {
+	return nullRateLimiter{}
+}
+
+func (rl *redisRateLimiter) RateLimit(name string, maxCalls uint64, per time.Duration) (bool, error) {
+	conn := rl.pool.Get()
+	defer conn.Close()
+
+	now := time.Now()
+	timestamp := now.Unix() - (now.Unix() % int64(per.Seconds()))
+
+	key := fmt.Sprintf("%s:%s:%d", rl.prefix, name, timestamp)
+
+	cur, err := redis.Int64(conn.Do("GET", key))
+	if err != nil && err != redis.ErrNil {
+		return false, err
+	}
+
+	if err != redis.ErrNil && uint64(cur) >= maxCalls {
+		return false, nil
+	}
+
+	_, err = conn.Do("WATCH", key)
+	if err != nil {
+		return false, err
+	}
+
+	connSend := func(commandName string, args ...interface{}) {
+		if err != nil && err != redis.ErrNil {
+			return
+		}
+		err = conn.Send(commandName, args...)
+	}
+	connSend("MULTI")
+	connSend("INCR", key)
+	connSend("EXPIRE", key, int64(per.Seconds()))
+	if err != nil {
+		return false, err
+	}
+
+	reply, err := conn.Do("EXEC")
+	if err != nil {
+		return false, err
+	}
+	if reply == nil {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (rl nullRateLimiter) RateLimit(name string, maxCalls uint64, per time.Duration) (bool, error) {
+	return true, nil
+}

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -1,0 +1,44 @@
+package ratelimit
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestRateLimit(t *testing.T) {
+	if os.Getenv("REDIS_URL") == "" {
+		t.Skip("skipping redis test since there is no REDIS_URL")
+	}
+
+	if time.Now().Minute() > 58 {
+		t.Log("Note: The TestRateLimit test is known to have a bug if run near the top of the hour. Since the rate limiter isn't a moving window, it could end up checking against two different buckets on either side of the top of the hour, so if you see that just re-run it after you've passed the top of the hour.")
+	}
+
+	rateLimiter := NewRateLimiter(os.Getenv("REDIS_URL"), fmt.Sprintf("worker-test-rl-%d", os.Getpid()))
+
+	ok, err := rateLimiter.RateLimit("slow", 2, time.Hour)
+	if err != nil {
+		t.Fatalf("rate limiter error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected to not get rate limited, but was limited")
+	}
+
+	ok, err = rateLimiter.RateLimit("slow", 2, time.Hour)
+	if err != nil {
+		t.Fatalf("rate limiter error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected to not get rate limited, but was limited")
+	}
+
+	ok, err = rateLimiter.RateLimit("slow", 2, time.Hour)
+	if err != nil {
+		t.Fatalf("rate limiter error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected to get rate limited, but was not limited")
+	}
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -27,6 +27,20 @@
 			"path": "/spew"
 		},
 		{
+			"importpath": "github.com/garyburd/redigo/internal",
+			"repository": "https://github.com/garyburd/redigo",
+			"revision": "836b6e58b3358112c8291565d01c35b8764070d7",
+			"branch": "master",
+			"path": "/internal"
+		},
+		{
+			"importpath": "github.com/garyburd/redigo/redis",
+			"repository": "https://github.com/garyburd/redigo",
+			"revision": "836b6e58b3358112c8291565d01c35b8764070d7",
+			"branch": "master",
+			"path": "/redis"
+		},
+		{
 			"importpath": "github.com/pmezard/go-difflib/difflib",
 			"repository": "https://github.com/pmezard/go-difflib",
 			"revision": "e8554b8641db39598be7f6342874b958f12ae1d4",


### PR DESCRIPTION
This is the same implementation that's in worker, and means that gcloud-cleanup will coordinate with worker to maintain below the rate limit.
