### PR TITLE
Remove heroku-bin Makefile argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,6 @@ GOBUILD_LDFLAGS ?= \
 
 export GO15VENDOREXPERIMENT
 
-.PHONY: heroku-bin
-heroku-bin:
-	$(GREP) worker Procfile
-	./build/$(OS)/$(ARCH)/gcloud-cleanup --version
-
 .PHONY: all
 all: clean test crossbuild
 


### PR DESCRIPTION
It doesn't seem to do anything except error if the binary hasn't been built, which doesn't seem to be what the makey-go buildpack is expecting.
