### PR TITLE
Bump default image limit to 1000

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -75,7 +75,7 @@ var (
 		},
 		cli.IntFlag{
 			Name:   "image-limit",
-			Value:  100,
+			Value:  1000,
 			Usage:  "number of images to fetch from job-board",
 			EnvVar: "GCLOUD_CLEANUP_IMAGE_LIMIT",
 		},

--- a/image_cleaner.go
+++ b/image_cleaner.go
@@ -166,6 +166,11 @@ func (ic *imageCleaner) fetchRegisteredImages() (map[string]bool, error) {
 		return images, err
 	}
 
+	if len(imageResp.Data) == ic.imageLimit {
+		return images,
+			fmt.Errorf("image count matches limit of %v, aborting", ic.imageLimit)
+	}
+
 	for _, imgRef := range imageResp.Data {
 		images[imgRef.Name] = true
 	}


### PR DESCRIPTION
and abort when fetched result size is equal to the limit, as this most likely means a bogus comparison is about to happen.  See also: https://www.traviscistatus.com/incidents/11hp8bhkrkn7
