### PR TITLE
Migrating to urfave/cli v2

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/travis-ci/gcloud-cleanup/ratelimit"
-	"github.com/urfave/cli"
+	"gopkg.in/urfave/cli.v2"
 )
 
 var (
@@ -34,13 +34,13 @@ func NewCLI(c *cli.Context) *CLI {
 	return &CLI{c: c, log: log}
 }
 
-func (c *CLI) Run() {
+func (c *CLI) Run() error {
 	c.setupLogger()
 	c.setupRateLimiter()
 
 	fields := logrus.Fields{}
 
-	for _, name := range c.c.GlobalFlagNames() {
+	for _, name := range c.c.FlagNames() {
 		fields[name] = c.c.Generic(name)
 	}
 
@@ -97,6 +97,7 @@ func (c *CLI) Run() {
 		c.log.WithField("duration", sleepDur).Info("sleeping")
 		time.Sleep(sleepDur)
 	}
+	return nil
 }
 
 func (c *CLI) setupComputeService(accountJSON string) error {

--- a/cli_test.go
+++ b/cli_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/urfave/cli"
+	"gopkg.in/urfave/cli.v2"
 )
 
 func TestNewCLI(t *testing.T) {

--- a/cmd/gcloud-cleanup/main.go
+++ b/cmd/gcloud-cleanup/main.go
@@ -4,15 +4,16 @@ import (
 	"os"
 
 	"github.com/travis-ci/gcloud-cleanup"
-	"github.com/urfave/cli"
+	"gopkg.in/urfave/cli.v2"
 )
 
 func main() {
-	app := cli.NewApp()
-	app.Version = gcloudcleanup.VersionString
-	app.Flags = gcloudcleanup.Flags
-	app.Action = func(c *cli.Context) {
-		gcloudcleanup.NewCLI(c).Run()
+	app := &cli.App{
+		Version: gcloudcleanup.VersionString,
+		Flags:   gcloudcleanup.Flags,
+		Action: func(c *cli.Context) error {
+			return gcloudcleanup.NewCLI(c).Run()
+		},
 	}
 	app.Run(os.Args)
 }

--- a/flags.go
+++ b/flags.go
@@ -3,91 +3,91 @@ package gcloudcleanup
 import (
 	"time"
 
-	"github.com/urfave/cli"
+	"gopkg.in/urfave/cli.v2"
 )
 
 var (
 	Flags = []cli.Flag{
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:   "account-json",
 			Value:  "{}",
 			Usage:  "file path to or json blob of GCE account stuff",
-			EnvVar: "GCLOUD_CLEANUP_ACCOUNT_JSON,GOOGLE_CREDENTIALS",
+			EnvVars: []string{"GCLOUD_CLEANUP_ACCOUNT_JSON", "GOOGLE_CREDENTIALS"},
 		},
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:   "project-id",
 			Usage:  "name of GCE project",
-			EnvVar: "GCLOUD_CLEANUP_PROJECT_ID,GCLOUD_PROJECT",
+			EnvVars: []string{"GCLOUD_CLEANUP_PROJECT_ID", "GCLOUD_PROJECT"},
 		},
-		cli.DurationFlag{
+		&cli.DurationFlag{
 			Name:   "instance-max-age",
 			Value:  3 * time.Hour,
 			Usage:  "max age for an instance to be considered deletable",
-			EnvVar: "GCLOUD_CLEANUP_INSTANCE_MAX_AGE",
+			EnvVars: []string{"GCLOUD_CLEANUP_INSTANCE_MAX_AGE"},
 		},
-		cli.StringSliceFlag{
+		&cli.StringSliceFlag{
 			Name:   "instance-filters",
 			Usage:  "filters used when fetching instances for deletion",
-			EnvVar: "GCLOUD_CLEANUP_INSTANCE_FILTERS",
+			EnvVars: []string{"GCLOUD_CLEANUP_INSTANCE_FILTERS"},
 		},
-		cli.StringSliceFlag{
+		&cli.StringSliceFlag{
 			Name:   "image-filters",
 			Usage:  "filters used when fetching images for deletion",
-			EnvVar: "GCLOUD_CLEANUP_IMAGE_FILTERS",
+			EnvVars: []string{"GCLOUD_CLEANUP_IMAGE_FILTERS"},
 		},
-		cli.StringSliceFlag{
+		&cli.StringSliceFlag{
 			Name:   "entities",
 			Usage:  "entities to clean up",
-			EnvVar: "GCLOUD_CLEANUP_ENTITIES",
+			EnvVars: []string{"GCLOUD_CLEANUP_ENTITIES"},
 		},
-		cli.DurationFlag{
+		&cli.DurationFlag{
 			Name:   "loop-sleep",
 			Value:  5 * time.Minute,
 			Usage:  "sleep time between loops",
-			EnvVar: "GCLOUD_CLEANUP_LOOP_SLEEP",
+			EnvVars: []string{"GCLOUD_CLEANUP_LOOP_SLEEP"},
 		},
-		cli.BoolFlag{
+		&cli.BoolFlag{
 			Name:   "once",
 			Usage:  "only run once, no looping",
-			EnvVar: "GCLOUD_CLEANUP_ONCE",
+			EnvVars: []string{"GCLOUD_CLEANUP_ONCE"},
 		},
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:   "rate-limit-redis-url",
 			Usage:  "URL to Redis instance to use for rate limiting",
-			EnvVar: "GCLOUD_CLEANUP_RATE_LIMIT_REDIS_URL",
+			EnvVars: []string{"GCLOUD_CLEANUP_RATE_LIMIT_REDIS_URL"},
 		},
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:   "rate-limit-prefix",
 			Usage:  "prefix for the rate limit key in Redis",
-			EnvVar: "GCLOUD_CLEANUP_RATE_LIMIT_PREFIX",
+			EnvVars: []string{"GCLOUD_CLEANUP_RATE_LIMIT_PREFIX"},
 		},
-		cli.IntFlag{
+		&cli.IntFlag{
 			Name:   "rate-limit-max-calls",
 			Value:  10,
 			Usage:  "number of calls per duration to let through to the GCE API",
-			EnvVar: "GCLOUD_CLEANUP_RATE_LIMIT_MAX_CALLS",
+			EnvVars: []string{"GCLOUD_CLEANUP_RATE_LIMIT_MAX_CALLS"},
 		},
-		cli.DurationFlag{
+		&cli.DurationFlag{
 			Name:   "rate-limit-duration",
 			Value:  1 * time.Second,
 			Usage:  "interval in which to let max-calls through to the GCE API",
-			EnvVar: "GCLOUD_CLEANUP_RATE_LIMIT_DURATION",
+			EnvVars: []string{"GCLOUD_CLEANUP_RATE_LIMIT_DURATION"},
 		},
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:   "job-board-url",
 			Value:  "http://localhost:4567",
 			Usage:  "url to job-board instance for fetching registered images",
-			EnvVar: "GCLOUD_CLEANUP_JOB_BOARD_URL,JOB_BOARD_URL",
+			EnvVars: []string{"GCLOUD_CLEANUP_JOB_BOARD_URL", "JOB_BOARD_URL"},
 		},
-		cli.BoolFlag{
+		&cli.BoolFlag{
 			Name:   "debug",
 			Usage:  "output more stuff",
-			EnvVar: "GCLOUD_CLEANUP_DEBUG,DEBUG",
+			EnvVars: []string{"GCLOUD_CLEANUP_DEBUG", "DEBUG"},
 		},
-		cli.BoolFlag{
+		&cli.BoolFlag{
 			Name:   "noop",
 			Usage:  "don't do mutative stuff",
-			EnvVar: "GCLOUD_CLEANUP_NOOP,NOOP",
+			EnvVars: []string{"GCLOUD_CLEANUP_NOOP", "NOOP"},
 		},
 	}
 )

--- a/instance_cleaner.go
+++ b/instance_cleaner.go
@@ -214,7 +214,7 @@ func (ic *instanceCleaner) fetchInstancesToDelete(instChan chan *instanceDeletio
 
 func (ic *instanceCleaner) deleteInstance(inst *compute.Instance) error {
 	if ic.noop {
-		ic.log.WithField("instance", inst.Name).Debug("not really deleting image")
+		ic.log.WithField("instance", inst.Name).Debug("not really deleting instance")
 		return nil
 	}
 

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -18,14 +18,6 @@
 			"notests": true
 		},
 		{
-			"importpath": "github.com/urfave/cli",
-			"repository": "https://github.com/urfave/cli",
-			"vcs": "git",
-			"revision": "168c95418e66e019fe17b8f4f5c45aa62ff80e23",
-			"branch": "master",
-			"notests": true
-		},
-		{
 			"importpath": "github.com/davecgh/go-spew/spew",
 			"repository": "https://github.com/davecgh/go-spew",
 			"vcs": "git",
@@ -146,6 +138,14 @@
 			"vcs": "git",
 			"revision": "31e6fd4bd5a98d8ee7673d24bc54ec73c31810dd",
 			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "gopkg.in/urfave/cli.v2",
+			"repository": "https://github.com/urfave/cli",
+			"vcs": "git",
+			"revision": "a095a5a89605c01901cebf5c889c68229b935225",
+			"branch": "v2",
 			"notests": true
 		}
 	]

--- a/version.go
+++ b/version.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/urfave/cli"
+	"gopkg.in/urfave/cli.v2"
 )
 
 var (


### PR DESCRIPTION
Via https://github.com/urfave/cli/blob/v2/cli-v1-to-v2 with manual changes noted in-line.
