### PR TITLE
Avoid leaking goroutines when cleaning up instances

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright © 2017 Travis CI
+Copyright © 2018 Travis CI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The code before this commit starts a goroutine every time `instanceCleaner.Run()` is called to print the errors from `instanceCleaner.fetchInstancesToDelete(…)`, but this goroutine will never finish. By closing the channel when the method is done, the goroutine is cleanly stopped.

Also removed sending `nil` to the channels, since this had no additional purpose when the channels are closed.