### PR TITLE
Introduce sample rate for getSerialPortOutput

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -19,7 +19,8 @@ import (
 )
 
 var (
-	errInvalidInstancesMaxAge = errors.New("invalid max age")
+	errInvalidInstancesMaxAge   = errors.New("invalid max age")
+	errInvalidArchiveSampleRate = errors.New("invalid archive sample rate")
 )
 
 type CLI struct {
@@ -162,6 +163,14 @@ func (c *CLI) cleanupInstances() error {
 			return errInvalidInstancesMaxAge
 		}
 
+		archiveSampleRate := c.c.Int64("archive-sample-rate")
+		if archiveSampleRate <= 0 {
+			c.log.WithFields(logrus.Fields{
+				"sample_rate": archiveSampleRate,
+			}).Error("archive sample rate must be positive")
+			return errInvalidArchiveSampleRate
+		}
+
 		c.log.WithFields(logrus.Fields{
 			"max_age":    c.c.Duration("instance-max-age"),
 			"tick":       c.c.Duration("rate-tick-limit"),
@@ -179,8 +188,9 @@ func (c *CLI) cleanupInstances() error {
 			projectID: c.c.String("project-id"),
 			filters:   filters,
 
-			archiveSerial: c.c.Bool("archive-serial"),
-			archiveBucket: c.c.String("archive-bucket"),
+			archiveSerial:     c.c.Bool("archive-serial"),
+			archiveBucket:     c.c.String("archive-bucket"),
+			archiveSampleRate: archiveSampleRate,
 
 			noop: c.c.Bool("noop"),
 

--- a/cli.go
+++ b/cli.go
@@ -3,6 +3,7 @@ package gcloudcleanup
 import (
 	"context"
 	"errors"
+	"math/rand"
 	"os"
 	"strings"
 	"time"
@@ -184,6 +185,8 @@ func (c *CLI) cleanupInstances() error {
 			cs:  c.cs,
 			sc:  c.sc,
 			log: c.log.WithField("component", "instance_cleaner"),
+
+			rand: rand.New(rand.NewSource(time.Now().UnixNano())),
 
 			projectID: c.c.String("project-id"),
 			filters:   filters,

--- a/flags.go
+++ b/flags.go
@@ -90,6 +90,12 @@ var (
 			Usage:   "bucket to which instance serial output will be archived before deleting",
 			EnvVars: []string{"GCLOUD_CLEANUP_ARCHIVE_BUCKET", "ARCHIVE_BUCKET"},
 		},
+		&cli.Int64Flag{
+			Name:    "archive-sample-rate",
+			Value:   1,
+			Usage:   "sample rate for archiving as an inverse fraction - for sample rate n, every nth event will be sampled",
+			EnvVars: []string{"GCLOUD_CLEANUP_ARCHIVE_SAMPLE_RATE", "ARCHIVE_SAMPLE_RATE"},
+		},
 		&cli.BoolFlag{
 			Name:    "debug",
 			Usage:   "output more stuff",

--- a/instance_cleaner.go
+++ b/instance_cleaner.go
@@ -27,6 +27,8 @@ type instanceCleaner struct {
 	sc  *storage.Client
 	log *logrus.Entry
 
+	rand *rand.Rand
+
 	projectID string
 	filters   []string
 
@@ -222,8 +224,7 @@ func (ic *instanceCleaner) archiveSerialConsoleOutput(inst *compute.Instance) er
 		return errNoStorageClient
 	}
 
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	archiveSampled := r.Float32() < (1.0 / float32(ic.archiveSampleRate))
+	archiveSampled := ic.rand.Float32() < (1.0 / float32(ic.archiveSampleRate))
 
 	if !archiveSampled {
 		ic.log.WithField("instance", inst.Name).Debug("skipping archive due to sample rate")

--- a/instance_cleaner_test.go
+++ b/instance_cleaner_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -27,6 +28,7 @@ func TestNewInstanceCleaner(t *testing.T) {
 
 	ic := &instanceCleaner{
 		log:               log.WithField("test", "yep"),
+		rand:              rand.New(rand.NewSource(4)),
 		rateLimiter:       rl,
 		rateLimitMaxCalls: 10,
 		rateLimitDuration: time.Second,
@@ -134,6 +136,7 @@ func TestInstanceCleaner_Run(t *testing.T) {
 		cs:                cs,
 		sc:                sc,
 		log:               log.WithField("test", "yep"),
+		rand:              rand.New(rand.NewSource(4)),
 		rateLimiter:       rl,
 		rateLimitMaxCalls: 10,
 		rateLimitDuration: time.Second,


### PR DESCRIPTION
We've been running into our api rate limit quota (20 req/s per user per project, 30 req/s total per project).

Serial output archiving is one of the main contributors to our api traffic (about 6 req/s).

This patch introduces a sample rate for archiving, so that we can reduce the volume of calls we make there.