### PR TITLE
Fix race condition between worker and gcloud-cleanup

### DIFF
--- a/instance_cleaner.go
+++ b/instance_cleaner.go
@@ -153,15 +153,6 @@ func (ic *instanceCleaner) fetchInstancesToDelete(ctx context.Context, instChan 
 
 				statusCounts[inst.Status]++
 
-				if inst.Status == "TERMINATED" {
-					log.WithFields(logrus.Fields{
-						"status": inst.Status,
-					}).Debug("sending instance for deletion")
-
-					instChan <- &instanceDeletionRequest{Instance: inst, Reason: "terminated"}
-					continue
-				}
-
 				ts, err := time.Parse(time.RFC3339, inst.CreationTimestamp)
 
 				if err != nil {


### PR DESCRIPTION
This attempts to address a race condition where both worker and gcloud-cleanup are trying to delete the same instance.

This happens because gcloud-cleanup attempts to delete any instance with status "TERMINATED". When worker finishes a job, it will first terminate the instance, and then delete it.

Because gcloud-cleanup does not consider the max age for TERMINATED instances, it will swoop in and sometimes delete the instance before worker gets the chance.

This is not impacting users, however it produces a lot of noise in the logs in form of 404 errors, for both worker and gcloud-cleanup.

This patch attempts to address the issue by only deleting instances of "max age". And leaving TERMINATED instances in place until the max age is exceeded.

refs https://github.com/travis-ci/reliability/issues/148