### PR TITLE
trace calls to google cloud api

### DIFF
--- a/gce.go
+++ b/gce.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"io/ioutil"
+	"net/http"
 	"strings"
 
 	"cloud.google.com/go/storage"
 	"cloud.google.com/go/trace"
+	"go.opencensus.io/plugin/ochttp"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
@@ -36,7 +38,11 @@ func buildGoogleComputeService(accountJSON string) (*compute.Service, error) {
 		TokenURL: "https://accounts.google.com/o/oauth2/token",
 	}
 
-	client := config.Client(oauth2.NoContext)
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{
+		Transport: &ochttp.Transport{},
+	})
+
+	client := config.Client(ctx)
 
 	cs, err := compute.New(client)
 	if err != nil {

--- a/instance_cleaner.go
+++ b/instance_cleaner.go
@@ -125,7 +125,7 @@ func (ic *instanceCleaner) fetchInstancesToDelete(ctx context.Context, instChan 
 
 		ic.apiRateLimit(ctx)
 		ic.log.WithField("page_token", pageTok).Debug("fetching instances aggregated list")
-		resp, err := listCall.Do()
+		resp, err := listCall.Context(ctx).Do()
 
 		if err != nil {
 			errChan <- err
@@ -216,7 +216,7 @@ func (ic *instanceCleaner) deleteInstance(ctx context.Context, inst *compute.Ins
 	}
 
 	ic.apiRateLimit(ctx)
-	_, err := ic.cs.Instances.Delete(ic.projectID, filepath.Base(inst.Zone), inst.Name).Do()
+	_, err := ic.cs.Instances.Delete(ic.projectID, filepath.Base(inst.Zone), inst.Name).Context(ctx).Do()
 	return err
 }
 


### PR DESCRIPTION
This one was a little tricky. The way we usually instrument HTTP clients is:

```
client := &http.Client{
    Transport: &ochttp.Transport{},
}
```

However, in this case the client is created by the `oauth2` package, which doesn't easily allow you to provide a custom transport. By reading through the source and looking around I did find that context trick. It's (kinda) documented [here](https://github.com/googleapis/google-api-go-client/blob/master/GettingStarted.md#using-api-keys).

To make sure those spans are associated with a parent, I had to make sure the context is passed through on the GCE api calls. I copied that part from https://github.com/travis-ci/worker/pull/452.

This is also going to be useful for worker tracing (https://github.com/travis-ci/reliability/issues/141).

refs https://github.com/travis-ci/reliability/issues/148