### PR TITLE
Use flags instead of Getenv() for Librato configuration

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -3,7 +3,6 @@ package gcloudcleanup
 import (
 	"context"
 	"math/rand"
-	"os"
 	"strings"
 	"time"
 
@@ -287,11 +286,11 @@ func (c *CLI) cleanupInstances() error {
 func (i *CLI) setupMetrics() {
 	go travismetrics.ReportMemstatsMetrics()
 
-	if os.Getenv("LIBRATO_EMAIL") != "" && os.Getenv("LIBRATO_TOKEN") != "" && os.Getenv("LIBRATO_SOURCE") != "" {
+	if i.c.String("librato-email") != "" && i.c.String("librato-token") != "" && i.c.String("librato-source") != "" {
 		i.log.Info("starting librato metrics reporter")
 
 		go librato.Librato(metrics.DefaultRegistry, time.Minute,
-			os.Getenv("LIBRATO_EMAIL"), os.Getenv("LIBRATO_TOKEN"), os.Getenv("LIBRATO_SOURCE"),
+			i.c.String("librato-email"), i.c.String("librato-token"), i.c.String("librato-source"),
 			[]float64{0.50, 0.75, 0.90, 0.95, 0.99, 0.999, 1.0}, time.Millisecond)
 	}
 }

--- a/flags.go
+++ b/flags.go
@@ -118,5 +118,20 @@ var (
 			Usage:   "don't do mutative stuff",
 			EnvVars: []string{"GCLOUD_CLEANUP_NOOP", "NOOP"},
 		},
+		&cli.StringFlag{
+			Name:    "librato-email",
+			Usage:   "librato account for collecting metrics",
+			EnvVars: []string{"GCLOUD_CLEANUP_LIBRATO_EMAIL", "LIBRATO_EMAIL"},
+		},
+		&cli.StringFlag{
+			Name:    "librato-token",
+			Usage:   "librato token for collecting metrics",
+			EnvVars: []string{"GCLOUD_CLEANUP_LIBRATO_TOKEN", "LIBRATO_TOKEN"},
+		},
+		&cli.StringFlag{
+			Name:    "librato-source",
+			Usage:   "librato source for collecting metrics",
+			EnvVars: []string{"GCLOUD_CLEANUP_LIBRATO_SOURCE", "LIBRATO_SOURCE"},
+		},
 	}
 )


### PR DESCRIPTION
The Librato config is managed through environment variables, this deviates from the rest of the configuration and makes it more complicated to configure it.

By using flags, we consolidate this configuration, it will allow us to prefix the variable with `GCLOUD_CLEANUP_` so it can be loaded from travis-keychain like the rest of the configuration.