### PR TITLE
Add tracing to ratelimiter (from worker)

### DIFF
--- a/instance_cleaner.go
+++ b/instance_cleaner.go
@@ -309,7 +309,7 @@ func (ic *instanceCleaner) apiRateLimit(ctx context.Context) error {
 	errCount := 0
 
 	for {
-		ok, err := ic.rateLimiter.RateLimit("gce-api", ic.rateLimitMaxCalls, ic.rateLimitDuration)
+		ok, err := ic.rateLimiter.RateLimit(ctx, "gce-api", ic.rateLimitMaxCalls, ic.rateLimitDuration)
 		if err != nil {
 			errCount++
 			if errCount >= 5 {


### PR DESCRIPTION
I'm trying to vendor the Ratelimit package from travis-ci/worker again, hoping this will help us find the GCE Rate limit. I'm not an actual gopher, so I'm doing a monkey-see monkey-do type of thing. 🙈

This change probably breaks image_cleaner.go as the gocontext is not available there.